### PR TITLE
fix: グローバル関数として登録

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,6 +1,9 @@
 import './bootstrap';
 
-function onClickCopy(elementName) {
+/**
+ * グローバル関数として登録
+ */
+window.onClickCopy = function (elementName) {
   const element  = document.getElementById(elementName);
   const value = element.value;
 


### PR DESCRIPTION
### 原因
vite や mix におけるwebpack の仕様上、各 .js ファイルが独立した名前空間を持つ (つまり、普通に function onClickCopy() { 〜 } のように定義されたものはその .js ファイルのローカル関数になる)、とのこと。

### 実装内容

- グローバル関数として登録するために、`window.onClickCopy = ()` のように無名関数としてプロパティとして設定